### PR TITLE
add prov-service and neo4j to docker-compose templates

### DIFF
--- a/docker-compose.dev.template.yml
+++ b/docker-compose.dev.template.yml
@@ -54,6 +54,35 @@ services:
         ROCHE_AZURE_AD_CLIENT_SECRET:
     depends_on:
         - mongo-dev
+        - prov-dev-server
+
+  neo4j-dev:
+    image: docker.synapse.org/syn18489221/phccp-neo4j
+    container_name: phccp-neo4j
+    ports:
+      - "7687:7687"
+      - "7474:7474"
+    environment:
+      NEO4J_AUTH: ${NEO4J_USERNAME}/${NEO4J_PASSWORD}
+    volumes:
+      - /tmp/neo4j/data:/var/lib/neo4j/data
+      - /tmp/neo4j/logs:/logs
+
+  prov-dev-server:
+    image: docker.synapse.org/syn18489221/prov-service:develop
+    command: python3 -m synprov --mock_db --db_size 30
+    container_name: phccp-prov
+    ports:
+      - "8080:8080"
+    environment:
+      NEO4J_SCHEME: bolt
+      NEO4J_HOST: neo4j-dev
+      NEO4J_PORT: 7687
+      NEO4J_USERNAME: ${NEO4J_USERNAME}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      FLASK_HOST: "0.0.0.0"
+    links:
+      - neo4j-dev
 
   mongo-dev:
     image: docker.synapse.org/syn18489221/phccp-mongo

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -41,18 +41,35 @@ services:
         - ./certs/server.cert:/usr/src/app/certs/server.cert:ro
     depends_on:
         - mongo-prod
-      # - provenance
+        - phccp-prov
 
-  # provenance:
-  #   image: docker.synapse.org/syn18489221/prov-service:v0.1
-  #   container_name: provenance
-  #   command: -m synprov
-  #   environment:
-  #     MONGODB_URI: 'mongodb://mongo:27017/provDB'
-  #   ports:
-  #     - 8081:8080
-  #   depends_on:
-  #     - mongo-prod
+  phccp-neo4j:
+    image: docker.synapse.org/syn18489221/phccp-neo4j
+    container_name: phccp-neo4j
+    ports:
+      - "7687:7687"
+      - "7474:7474"
+    environment:
+      NEO4J_AUTH: ${NEO4J_USERNAME}/${NEO4J_PASSWORD}
+    volumes:
+      - /tmp/neo4j/data:/var/lib/neo4j/data
+      - /tmp/neo4j/logs:/logs
+
+  phccp-prov:
+    image: docker.synapse.org/syn18489221/prov-service:develop
+    command: python3 -m synprov
+    container_name: phccp-prov
+    ports:
+      - "8080:8080"
+    environment:
+      NEO4J_SCHEME: bolt
+      NEO4J_HOST: phccp-neo4j
+      NEO4J_PORT: 7687
+      NEO4J_USERNAME: ${NEO4J_USERNAME}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      FLASK_HOST: "0.0.0.0"
+    links:
+      - phccp-neo4j
 
   mongo-prod:
     image: docker.synapse.org/syn18489221/phccp-mongo


### PR DESCRIPTION
Updated dev docker-compose as well, for the sake of testing — but can ignore if preferred.