### PR TITLE
Update RDP link to demo site

### DIFF
--- a/server/config/seeds/default/data-catalogs.js
+++ b/server/config/seeds/default/data-catalogs.js
@@ -9,8 +9,8 @@ let dataCatalogs = [{
     description: 'A discoverability portal for the GREX framework',
     apiType: 'CKAN',
     picture: 'assets/images/320px-Roche_Logo.svg.png',
-    apiServerUrl: 'https://data.roche.com/api/3',  // 'http://data.roche.com/api/3',
-    website: 'https://data.roche.com/',  // 'http://data.roche.com',
+    apiServerUrl: 'https://demo-data.roche.com/api/3',  // 'http://data.roche.com/api/3',
+    website: 'https://demo-data.roche.com/',  // 'http://data.roche.com',
     organization: geneId,
     createdBy: adminUserId
 }, {


### PR DESCRIPTION
The CORS origin settings in demo-data.roche.com are set as `ckan.cors.origin_allow_all = True` so this should let us query that data catalog and hopefully patch #294.