### PR TITLE
Add service to create new provenance activities

### DIFF
--- a/client/components/provenance/capture-provenance-activity.service.ts
+++ b/client/components/provenance/capture-provenance-activity.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from "@angular/core";
+import { AuthService } from "components/auth/auth.service";
+import { Subscription } from "rxjs";
+import { User } from "models/auth/user.model";
+import { ProvenanceService } from "./provenance.service";
+
+@Injectable()
+export class CaptureProvenanceActivityService {
+    authInfoSub: Subscription;
+    currentUser: User;
+
+    static parameters = [AuthService, ProvenanceService]
+    constructor(private authService: AuthService, private provenanceService: ProvenanceService) {
+        this.authInfoSub = this.authService.authInfo()
+            .subscribe(authInfo => {
+                this.currentUser = authInfo.user;
+            }, err => console.log(err));
+
+    }
+
+    save({ generatedName, generatedTargetId, generatedClass, generatedSubClass }) {
+        const activity = {
+            agents: [{
+                userId: this.currentUser._id,
+                name: this.currentUser.name,
+                role: this.currentUser.role,
+            }],
+            description: '',
+            class: 'Report generation',
+            generated: [{
+                name: generatedName,
+                role: '',
+                targetId: generatedTargetId,
+                targetVersionId: 1,
+                class: generatedClass,
+                subclass: generatedSubClass,
+            }],
+            name: `Creation of ${generatedName}`,
+            used: [{
+                name: '',
+                role: '',
+                targetId: '',
+                targetVersionId: 1,
+                class: '',
+                subclass: ''
+            }]
+        }
+
+        this.provenanceService.createProvenanceActivity(activity)
+    }
+}

--- a/client/components/provenance/provenance.module.ts
+++ b/client/components/provenance/provenance.module.ts
@@ -8,7 +8,7 @@ import { ActivityNodeComponent } from './provenance-graph/activity-node/activity
 import { ReferenceNodeComponent } from './provenance-graph/reference-node/reference-node.component';
 import { AgentNodeComponent } from './provenance-graph/agent-node/agent-node.component';
 import { ProvenanceLinkComponent } from './provenance-graph/provenance-link/provenance-link.component';
-
+import { CaptureProvenanceActivityService } from './capture-provenance-activity.service'
 @NgModule({
     imports: [
         BrowserModule,
@@ -18,7 +18,8 @@ import { ProvenanceLinkComponent } from './provenance-graph/provenance-link/prov
         ProvenanceService,
         ProvenanceGraphComponent,
         ProvenanceNodeComponent,
-        ProvenanceLinkComponent
+        ProvenanceLinkComponent,
+        CaptureProvenanceActivityService
     ],
     declarations: [
         ProvenanceGraphComponent,


### PR DESCRIPTION
Issue: https://github.com/Sage-Bionetworks/PHCCollaborationPortal/issues/288

# What does this PR do
- Experiments with an approach using `services` to create new provenance activities on given actions.

# Discussion
I originally planned on using a directive to accomplish this, the idea was to have the directive listen to onClick events of the elements that got attached it to. However, this wouldn't work because if we want to create a new provenance activity we first need the recently created object, in this case, the new Insight.
That's why I opted for the service approach. We'll need to call `CreateProvenanceActivitiyService::save` after an insight or any other entity has successfully been saved.
