### PR TITLE
Add more info to activity graph tooltips

### DIFF
--- a/client/components/provenance/provenance-graph/provenance-node/provenance-node.component.ts
+++ b/client/components/provenance/provenance-graph/provenance-node/provenance-node.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Node } from '../../../d3/models/node';
 import * as d3 from 'd3';
-import { defaultTo, get } from 'lodash';
+import { get } from 'lodash';
 
 @Component({
     selector: '[provenanceNode]',
@@ -24,12 +24,17 @@ export class ProvenanceNodeComponent implements OnInit {
     }
 
     getTooltipContent() {
+        const { label, nodeClass, subclass, provenanceNode } = this.node
+
+        const typeText = nodeClass ? `<strong>Type: </strong>${nodeClass}` : ''
+        const subtypeText = subclass && subclass !== nodeClass ? `<br>Subtype: ${subclass}` : ''
+
         return `
-            <div><strong>${this.node.label}: </strong>${get(this.node.provenanceNode, 'properties.name')}</div>
+            <div><strong>${label}: </strong>${get(provenanceNode, 'properties.name')}</div>
             <div>
                 <span>
-                    <strong>Type: </strong>${defaultTo(this.node.nodeClass, '')}
-                    ${this.node.subclass ? `<br>Subtype: ${this.node.subclass}` : ''}
+                    ${typeText}
+                    ${subtypeText}
                 </span>
             </div>
         `;


### PR DESCRIPTION
Fixes #307. 

Looks good for most Reference and Activity nodes:

![image](https://user-images.githubusercontent.com/5033229/62171261-3baca000-b2e3-11e9-9306-f80f06543db5.png)

![image](https://user-images.githubusercontent.com/5033229/62171287-49fabc00-b2e3-11e9-885e-8b0c3dcfbe5a.png)

For Agents and Tool References, I haven't quite figured out the JS conditionals to solve cases where:

Node has no type (`nodeClass`) — should ignore "Type: " line in this case:
![image](https://user-images.githubusercontent.com/5033229/62171305-5717ab00-b2e3-11e9-8b3b-961c1fd30295.png)

Node subtype (`subclass`) is same as type — should ignore "Subtype: " line in this case:
![image](https://user-images.githubusercontent.com/5033229/62171314-63036d00-b2e3-11e9-83e7-3ebca7ee558a.png)

(the former might be something I should change on the provenance server side... but probably a condition worth supporting)

Here's the relevant code in `provenance-node-component.ts`:
```typescript
getTooltipContent() {
    return `
        <div><strong>${this.node.label}: </strong>${get(this.node.provenanceNode, 'properties.name')}</div>
        <div>
            <span>
                <strong>Type: </strong>${defaultTo(this.node.nodeClass, '')}
                ${this.node.subclass ? `<br>Subtype: ${this.node.subclass}` : ''}
            </span>
        </div>
    `;
}
```