### PR TITLE
added the selected property to mat-chip to show different colors

### DIFF
--- a/client/components/entity/entity-access-list/entity-access-list.html
+++ b/client/components/entity/entity-access-list/entity-access-list.html
@@ -13,8 +13,8 @@
                 <p matLine>{{ perm.user.username }}</p>
 
                 <mat-chip-list  class="app-entity-access-list-status">
-                  <mat-chip *ngIf="isPending(perm)" color="warn">Pending</mat-chip>
-                  <mat-chip *ngIf="isDeclined(perm)" color="warn">Declined</mat-chip>
+                  <mat-chip *ngIf="isPending(perm)" color="warn" selected>Pending</mat-chip>
+                  <mat-chip *ngIf="isDeclined(perm)" color="warn" selected>Declined</mat-chip>
                 </mat-chip-list>
 
                 <mat-select class="app-entity-access-list-access" [disabled]="disableAccessMenu(perm)" [(ngModel)]="perm.access" (selectionChange)="changeCollaboratorAccess($event, perm)">


### PR DESCRIPTION
The "Pending" and "Declined" `mat-chip` now appear as orange when using `color=warn`  in the invites section of projects. 

![sharing-settings](https://user-images.githubusercontent.com/12868382/63124644-993a2100-bf60-11e9-8147-83a5b0f4bce5.png)

 Addresses ticket #359 