### PR TITLE
Update color of icons in sidenav header

### DIFF
--- a/client/components/messaging/thread-sidenav/_thread-sidenav-theme.scss
+++ b/client/components/messaging/thread-sidenav/_thread-sidenav-theme.scss
@@ -6,18 +6,12 @@
   $foreground: map-get($theme, foreground);
 
   .app-thread-header  {
-      color: mat-color($primary, default-contrast);
+      mat-icon {
+          color: mat-color($primary, default-contrast);
+      }
   }
   .app-message-thread-header {
       background: mat-color($primary);
   }
-  .app-message-thread-header-close {
-    color: mat-color($primary, default-contrast);
-  }
-  .app-thread-header-edit {
-    color: mat-color($primary, default-contrast);
-  }
-  .app-thread-header-pin {
-    color: mat-color($primary, default-contrast);
-  }
 }
+


### PR DESCRIPTION
Makes it so that the icons use the `default-contrast` of the header (e.g. matches the same color as the text). Addressed #415 