### PR TITLE
Corrected broken validation path for tool name

### DIFF
--- a/client/app/tool/tool-edit/tool-edit.component.ts
+++ b/client/app/tool/tool-edit/tool-edit.component.ts
@@ -34,8 +34,8 @@ export class ToolEditComponent implements OnInit, OnDestroy {
             this.editForm = this.formBuilder.group({
                 title: ['', [
                     Validators.required,
-                    Validators.minLength(config.models.tool.title.minlength),
-                    Validators.maxLength(config.models.tool.title.maxlength)
+                    Validators.minLength(config.models.tool.name.minlength),
+                    Validators.maxLength(config.models.tool.name.maxlength)
                 ]],
                 description: ['', [
                     Validators.required,

--- a/client/app/tool/tool-new/tool-new.component.ts
+++ b/client/app/tool/tool-new/tool-new.component.ts
@@ -35,8 +35,8 @@ export class ToolNewComponent implements OnInit, OnDestroy {
         this.newForm = this.formBuilder.group({
             title: ['', [
                 Validators.required,
-                Validators.minLength(config.models.tool.title.minlength),
-                Validators.maxLength(config.models.tool.title.maxlength)
+                Validators.minLength(config.models.tool.name.minlength),
+                Validators.maxLength(config.models.tool.name.maxlength)
             ]],
             description: ['', [
                 Validators.required,


### PR DESCRIPTION
This PR fixes an issue where our tool editing components were not updated to match a recent config change for tool validation.