### PR TITLE
EntityService.createAttachments returns of([]) when there are no atta…

### DIFF
--- a/client/components/entity/entity-attachment/entity-attachment-list/entity-attachment-list.component.ts
+++ b/client/components/entity/entity-attachment/entity-attachment-list/entity-attachment-list.component.ts
@@ -207,7 +207,11 @@ export class EntityAttachmentListComponent<E extends Entity> implements OnInit, 
                 atta.parentEntityId = entity._id; // TODO: must be set by the backend
                 return atta;
             });
-            return this.entityService.createAttachments(entity, attachments);
+            if (attachments.length > 0) {
+                return this.entityService.createAttachments(entity, attachments);
+            } else {
+                return of<EntityAttachment[]>([]);
+            }
         }
     }
 


### PR DESCRIPTION
…chments (fix #560)

This solves a bug that prevents users to create an Insight when there are no attachments.