### PR TITLE
Prepare public release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,23 +28,23 @@ script:
 after_success:
   - bash .travis/after-success.sh || travis_terminate 1;
 
-deploy:
-  - provider: script
-    script: bash .travis/docker-deploy.sh
-    on:
-      branch: develop
-  - provider: script
-    script: bash .travis/docker-deploy.sh
-    on:
-      tags: true
-  - provider: codedeploy
-    bucket: "phc-codedeploy-essentials-codedeploys3bucket-jumhvxvmnql0"
-    key: deploy.zip
-    bundle_type: zip
-    access_key_id: "${CODEDEPLOY_ACCESS_KEY_ID}"
-    secret_access_key: "${CODEDEPLOY_SECRET_ACCESS_KEY}"
-    application: "phc-codedeploy-CodeDeployApplication-1JIG4ADRRDKT4"
-    deployment_group: "phc-codedeploy-DeploymentGroup-3DWDGW9ASVEZ"
-    region: "us-east-1"
-    on:
-      branch: develop
+# deploy:
+#   - provider: script
+#     script: bash .travis/docker-deploy.sh
+#     on:
+#       branch: develop
+#   - provider: script
+#     script: bash .travis/docker-deploy.sh
+#     on:
+#       tags: true
+#   - provider: codedeploy
+#     bucket: "phc-codedeploy-essentials-codedeploys3bucket-jumhvxvmnql0"
+#     key: deploy.zip
+#     bundle_type: zip
+#     access_key_id: "${CODEDEPLOY_ACCESS_KEY_ID}"
+#     secret_access_key: "${CODEDEPLOY_SECRET_ACCESS_KEY}"
+#     application: "phc-codedeploy-CodeDeployApplication-1JIG4ADRRDKT4"
+#     deployment_group: "phc-codedeploy-DeploymentGroup-3DWDGW9ASVEZ"
+#     region: "us-east-1"
+#     on:
+#       branch: develop

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "node",
             "request": "attach",
-            "name": "[NODE] Attach to PHCCP back-end",
+            "name": "[NODE] Attach to SBCP back-end",
             "processId": "${command:PickProcess}",
             "restart": true,
             "protocol": "inspector",
@@ -15,7 +15,7 @@
         {
             "type": "chrome",
             "request": "launch",
-            "name": "[CHROME] PHCCP front-end",
+            "name": "[CHROME] SBCP front-end",
             "url": "https://localhost/home",
             "webRoot": "${workspaceFolder}"
         },

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# PHC Collaboration Portal
+# SageBio Collaboration Portal
+
+Collaboration Portal developed by Sage Bionetworks
 
 
  CI | Branch  | Build Status | Coverage
  ---|---------|--------------|----------------
 Travis | develop | [![Build Status develop branch](https://travis-ci.com/Sage-Bionetworks/PHCCollaborationPortal.svg?token=yP6gcHRqAyiNe3nCgxVR&branch=develop)](https://travis-ci.com/Sage-Bionetworks/PHCCollaborationPortal) | [![codecov](https://codecov.io/gh/Sage-Bionetworks/PHCCollaborationPortal/branch/develop/graph/badge.svg?token=ApC9zY6G1B)](https://codecov.io/gh/Sage-Bionetworks/PHCCollaborationPortal)
 Travis | master  | [![Build Status master branch](https://travis-ci.com/Sage-Bionetworks/PHCCollaborationPortal.svg?token=yP6gcHRqAyiNe3nCgxVR&branch=develop)](https://travis-ci.com/Sage-Bionetworks/PHCCollaborationPortal)
-
-Personalized Health Care (PHC) Collaboration Portal by Sage Bionetworks for Roche/Genentech
 
 ## Getting Started
 
@@ -18,4 +18,4 @@ Personalized Health Care (PHC) Collaboration Portal by Sage Bionetworks for Roch
 
 ### Developing
 
-See the section [Deploying the portal](https://github.com/Sage-Bionetworks/PHCCollaborationPortal/wiki/Deploying-the-portal).
+See the section [Deploying the portal](https://github.com/Sage-Bionetworks/sagebio-collaboration-portal/wiki/Deploying-the-portal).

--- a/client/app/account/login/login.html
+++ b/client/app/account/login/login.html
@@ -13,7 +13,7 @@
                     [formGroup]="loginForm"
                     novalidate
                 >
-                    <h3>Sign in with your PHCCP account</h3>
+                    <h3>Sign in with your SBCP account</h3>
                     <mat-form-field class="form-field-full-width">
                         <input
                             id="app-login-email"

--- a/client/app/dataset/dataset-page/dataset.component.ts
+++ b/client/app/dataset/dataset-page/dataset.component.ts
@@ -63,7 +63,7 @@ export class DatasetComponent implements OnInit, OnDestroy {
     getToolsByResource(resource: CkanDatasetResource): Tool[] {
         if (this.catalog._id === '5cb6a048e7bdc7740874fd92' &&  // Sage Ckan
             resource.id === 'cf4b928f-06e7-4049-aa46-06a88dc36830') {  // airway.RDS
-            return this.tools.filter(tool => ['PHCCP Shiny Tool Example'].includes(tool.title));
+            return this.tools.filter(tool => ['SBCP Shiny Tool Example'].includes(tool.title));
         } else if (this.catalog._id === '5cb6a048e7bdc7740874f356' &&  // Kumar's CKAN
             resource.id === '15135bef-fc90-4656-bf05-f3b7a50f0d74') {  // PNG image
             return this.tools.filter(tool => ['IRIS Enterprise Explorer'].includes(tool.title));
@@ -87,7 +87,7 @@ export class DatasetComponent implements OnInit, OnDestroy {
             return this.tools.filter(tool => ['RStudio', 'Jupyter'].includes(tool.title));
         } else if (this.catalog._id === '5cb6a048e7bdc7740874fd92' &&  // Sage Ckan
             dataset.id === 'fc0633f8-6a9d-4cb7-896d-186d0db19ff8') {  // Airway Smooth Muscle Cell Line RNA-seq
-            return this.tools.filter(tool => ['PHCCP Shiny Tool Example'].includes(tool.title));
+            return this.tools.filter(tool => ['SBCP Shiny Tool Example'].includes(tool.title));
         }
     }
 

--- a/client/app/docs/docs.html
+++ b/client/app/docs/docs.html
@@ -1,7 +1,7 @@
 <header class="app-header-background">
     <div class="app-header-section">
         <div class="app-header-headline-alt">
-            <h1>PHCCP Documentation</h1>
+            <h1>SBCP Documentation</h1>
             <h3>Learn about the different types of information and actions in the portal.</h3>
         </div>
     </div>

--- a/client/app/main/main.html
+++ b/client/app/main/main.html
@@ -2,11 +2,11 @@
     <div class="app-header-section">
         <div *ngIf="!isLoggedIn" class="app-header-headline">
 	        <h2> Welcome to the </h2>
-            <h1 class="mat-h1">PHC-IX Collaboration Portal</h1>
+            <h1 class="mat-h1">SageBio Collaboration Portal</h1>
             <h3>A collaborative space based on FAIR principles to enable data discovery and tracking, reuse, and insight sharing.</h3>
         </div>
         <div *ngIf="isLoggedIn" class="app-header-headline-alt">
-            <h1>PHC-IX Collaboration Portal</h1>
+            <h1>SageBio Collaboration Portal</h1>
             <h3>A collaborative space based on FAIR principles to enable data discovery and tracking, reuse, and insight sharing.</h3>
         </div>
         <div class="app-header-start">

--- a/client/components/footer/footer.html
+++ b/client/components/footer/footer.html
@@ -2,8 +2,8 @@
     <div class="app-footer-list">
         <div class="app-footer-logo">
             <div class="footer-logo">
-<!--                <img class="app-logo" [src]="'assets/images/app-logo.svg'" alt="PHCCP logo">-->
-                <span>PHC-IX Collaboration Portal</span>
+<!--                <img class="app-logo" [src]="'assets/images/app-logo.svg'" alt="SBCP logo">-->
+                <span>SageBio Collaboration Portal</span>
             </div>
         </div>
 
@@ -14,8 +14,7 @@
         </div>
 
         <div class="app-footer-copyright">
-            <!-- <span>© 2019</span> -->
-            <span>Built in collaboration with Sage Bionetworks</span>
+            <span>Built by Sage Bionetworks</span>
         </div>
     </div>
 </footer>

--- a/client/components/navbar/navbar.html
+++ b/client/components/navbar/navbar.html
@@ -4,9 +4,9 @@
     </div>
 
     <div class="app-navbar-hide-small">
-        <a mat-button class="app-button" routerLink="/" aria-label="PHCCP">
-            <!--            <img class="app-logo" [src]="'assets/images/app-logo.svg'" alt="PHCCP logo">-->
-            <span>PHCCP</span>
+        <a mat-button class="app-button" routerLink="/" aria-label="SBCP">
+            <!--            <img class="app-logo" [src]="'assets/images/app-logo.svg'" alt="SBCP logo">-->
+            <span>SBCP</span>
         </a>
         <a *ngIf="isLoggedIn" mat-button class="app-button" routerLink="/resources" aria-label="Resources">Resources</a>
         <a *ngIf="isLoggedIn" mat-button class="app-button" routerLink="/insights" aria-label="Insights">Insights</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "phccp",
-    "version": "1.0.0-alpha.14",
+    "version": "1.0.0-alpha.15",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "phccp",
-    "version": "1.0.0-alpha.14",
+    "version": "1.0.0-alpha.15",
     "main": "server/index.js",
     "dependencies": {
         "@babel/polyfill": "^7.6.0",

--- a/server/config/environment/shared.js
+++ b/server/config/environment/shared.js
@@ -198,7 +198,7 @@ export const defaultTools = [
     },
     {
         value: '5cb7acb3167e4f14b29dfb1b',
-        title: 'PHCCP Shiny Tool Example',
+        title: 'SBCP Shiny Tool Example',
     },
 ];
 

--- a/server/config/seeds/development/provenance.js
+++ b/server/config/seeds/development/provenance.js
@@ -30,7 +30,7 @@ let activities = [
                 subclass: 'Project'
             },
             {
-                name: 'PHCCP Shiny Tool Example',
+                name: 'SBCP Shiny Tool Example',
                 role: '',
                 targetId: '5cb7acb3167e4f14b29dfb1b',
                 targetVersionId: '1',

--- a/server/config/seeds/development/tools.js
+++ b/server/config/seeds/development/tools.js
@@ -5,7 +5,7 @@ import config from '../../environment';
 
 const phccpShinyToolExample = {
     _id: new mongoose.Types.ObjectId('5cb7acb3167e4f14b29dfb1b'),
-    title: 'PHCCP Shiny Tool Example',
+    title: 'SBCP Shiny Tool Example',
     description: `A Shiny App for demonstrating features of this collaboration ` +
         `portal.`,
     picture: 'assets/images/320px-shinyLogo.png',


### PR DESCRIPTION
This project was referred to as PHC Collaboration Portal. As we have decided to release this repo publicly to be able to share it and reuse its code base in other project, we need to remove references to Roche/Genentech and PHC. The new name of the portal is "SageBio Collaboration Portal".

List of GitHub resources: https://github.com/orgs/Sage-Bionetworks/projects/6/settings/linked_repositories

Preparer the following components used by the portal infrastructure

- [x] sbcp-mongo
- [x] prov-service
- sagebio-collaboration-portal

## Docker images

- https://hub.docker.com/r/sagebionetworks/sagebio-collaboration-portal
- https://hub.docker.com/r/sagebionetworks/sbcp-mongo
- https://hub.docker.com/r/sagebionetworks/prov-service

## Important

- Make sure that the CI and deployment system - using AWS CodeDeploy - still works after renaming resources.
- The portal is not fully functional (uncomplete backend authorization) but the code base is valuable to ongoing Sage projects.

## Check List

- Add CodeDeploy trigger to the GH repo `sbcp-mongo`
- Add GH Action Badge `Docker Image` or `Docker Hub`
- Uniformize README format of the components
- Disable GH Wiki and Projects when not used
- Add GH Issue templates
- Remove old branches
- Make sure that each repo has at least two admins
- Rename Codecov/Coveralls.io projects when needed

## Notes

- The repo `prov-service` has been updated. The deployment should ultimately be OK despite Travis failing and a few tickets open.